### PR TITLE
Install ESSTRA into GCC plugin directory, instead of /usr/share (Closes #15)

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -5,6 +5,8 @@ CXX := g++
 PLUGIN_INCLUDE_DIR := $(shell $(CXX) -print-file-name=plugin)
 CXXFLAGS += -Wall -Wextra
 CXXFLAGS += -I$(PLUGIN_INCLUDE_DIR)/include -fPIC -fno-rtti -O2 -std=c++14
+GCC_MAJOR_VERSION := $(shell $(CXX) -dumpversion)
+GCC_ARCH := $(shell $(CXX) -dumpmachine)
 
 ESSTRACORE_SOURCES := esstracore.cpp
 ESSTRACORE := $(ESSTRACORE_SOURCES:.cpp=.so)
@@ -20,7 +22,7 @@ ESSTRACORE_SOURCES += $(WJCRYPTLIB_FILES)
 CXXFLAGS += -I $(WJCRYPTLIB_DIR)
 
 PREFIX ?= /usr/local
-INSTALLDIR := $(DESTDIR)/$(PREFIX)/share/esstra
+INSTALLDIR := $(DESTDIR)/$(PREFIX)/lib/gcc/$(GCC_ARCH)/$(GCC_MAJOR_VERSION)/plugin/
 
 SPECFILE := $(shell dirname `gcc -print-libgcc-file-name`)/specs
 


### PR DESCRIPTION
On my Debian unstable system, GCC has its own plugin directory as below:

/usr/lib/gcc/x86_64-linux-gnu/13/plugin/:
libcc1plugin.so
libcc1plugin.so.0
libcc1plugin.so.0.0.0
libcp1plugin.so
libcp1plugin.so.0
libcp1plugin.so.0.0.0

/usr/lib/gcc/x86_64-linux-gnu/14/plugin/:
libcc1plugin.so
libcc1plugin.so.0
libcc1plugin.so.0.0.0
libcp1plugin.so
libcp1plugin.so.0
libcp1plugin.so.0.0.0

We should put it into there: install such library files into /usr/share *violates* FHS (Filesystem Hierarchy Standard), since files in /usr/share are expected as arch-independent data.

See https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s11.html