### PR TITLE
Install esstra.py without .py extension

### DIFF
--- a/util/Makefile
+++ b/util/Makefile
@@ -3,13 +3,13 @@
 
 PREFIX ?= /usr/local
 INSTALLDIR := $(DESTDIR)/$(PREFIX)/bin
-ESSTRAUTIL := esstra.py
+ESSTRAUTIL := esstra
 
 .PHONY: all clean install
 
 all clean:
 	@echo do nothing for target: "$@"
 
-install: $(ESSTRAUTIL)
+install: $(ESSTRAUTIL).py
 	install -m 755 -d $(INSTALLDIR)
-	install -m 755 $(ESSTRAUTIL) $(INSTALLDIR)
+	install -m 755 $(ESSTRAUTIL).py $(INSTALLDIR)/$(ESSTRAUTIL)


### PR DESCRIPTION
It is tiny, tiny thing: it'd be better to install it as just esstra, without language extension

See https://lintian.debian.org/tags/script-with-language-extension.html for the reference.
Thank you.