### PR TITLE
bug fix: some directories to appear multiple times

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -4,7 +4,7 @@
 CXX := g++
 PLUGIN_INCLUDE_DIR := $(shell $(CXX) -print-file-name=plugin)
 CXXFLAGS += -Wall -Wextra
-CXXFLAGS += -I$(PLUGIN_INCLUDE_DIR)/include -fPIC -fno-rtti -O2 -std=c++14
+CXXFLAGS += -I$(PLUGIN_INCLUDE_DIR)/include -fPIC -fno-rtti -O2 -std=c++17
 GCC_MAJOR_VERSION := $(shell $(CXX) -dumpversion)
 GCC_ARCH := $(shell $(CXX) -dumpmachine)
 


### PR DESCRIPTION
Before categorizing files by directory, they were sorted by full path, which caused some directories to appear multiple times.

For example:

```yaml
SourceFiles:
  /home/snagao/esstra/samples/hello:
  - File: hello.c
    SHA1: '4bbee85215cbcb6a4f1625e4851cca19b0d3f6e2'
       :
   (snip)
       :
  /usr/include/x86_64-linux-gnu/bits:               # <- XXX
  - File: floatn-common.h
    SHA1: '3f37104123a2e6180621331c1da87125808e47bd'
       :
   (snip)
       :
  /usr/include/x86_64-linux-gnu/bits/types:
  - File: FILE.h
    SHA1: '497924e329d53517631713ae52acb73e870d7d65'
       :
   (snip)
       :
  /usr/include/x86_64-linux-gnu/bits:                # <- XXX
  - File: typesizes.h
    SHA1: 'ee94b5a60d007c23bdda9e5c46c8ba40f4eb402c'
       :
   (snip)
       :
```