### PR TITLE
Restructure the YAML data schema and set DataFormatVersion to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,14 +154,16 @@ would generate an output as follows:
 Headers:
   ToolName: ESSTRA Core
   ToolVersion: 0.1.1-develop
-  DataFormatVersion: 0.1.0-develop
+  DataFormatVersion: 0.1.0
   InputFileNames:
   - hello.c
 SourceFiles:
-  /home/snagao/esstra/samples/hello:
+- Directory: /home/snagao/esstra/samples/hello
+  Files:
   - File: hello.c
     SHA1: 4bbee85215cbcb6a4f1625e4851cca19b0d3f6e2
-  /usr/include:
+- Directory: /usr/include
+  Files:
   - File: features-time64.h
     SHA1: 57c3c8093c3af70e5851f6d498600e2f6e24fdeb
   - File: features.h
@@ -170,12 +172,14 @@ SourceFiles:
     SHA1: 2fef05d80514ca0be77efec90bda051cf87d771f
   - File: stdio.h
     SHA1: c7181b48c4194cd122024971527aab4056baf600
-  /usr/include/x86_64-linux-gnu/bits:
+- Directory: /usr/include/x86_64-linux-gnu/bits
+  Files:
   - File: typesizes.h
     SHA1: ee94b5a60d007c23bdda9e5c46c8ba40f4eb402c
   - File: wordsize.h
     SHA1: 281ddd3c93f1e8653e809a45b606574c9b691092
-  /usr/include/x86_64-linux-gnu/bits/types:
+- Directory: /usr/include/x86_64-linux-gnu/bits/types
+  Files:
   - File: FILE.h
     SHA1: 497924e329d53517631713ae52acb73e870d7d65
   - File: __FILE.h
@@ -188,15 +192,18 @@ SourceFiles:
     SHA1: e3a4f2ee55e635520db0b4610d2b361e9ce41de7
   - File: struct_FILE.h
     SHA1: 1dbf8bac589cb09e09aa4c1d36913e549a57bcf0
-  /usr/include/x86_64-linux-gnu/gnu:
+- Directory: /usr/include/x86_64-linux-gnu/gnu
+  Files:
   - File: stubs-64.h
     SHA1: f7603fa3908b56e9d1b33c91590db3252e13a799
   - File: stubs.h
     SHA1: be168037b7503a82b1cf694cdbac8c063bb6e476
-  /usr/include/x86_64-linux-gnu/sys:
+- Directory: /usr/include/x86_64-linux-gnu/sys
+  Files:
   - File: cdefs.h
     SHA1: a419a6372029d89ba38ada0811d34f51df8d09b7
-  /usr/lib/gcc/x86_64-linux-gnu/11/include:
+- Directory: /usr/lib/gcc/x86_64-linux-gnu/11/include
+  Files:
   - File: stdarg.h
     SHA1: fa23f49da8a0a5068b781dff7182f1a1c363dc30
   - File: stddef.h

--- a/core/Makefile
+++ b/core/Makefile
@@ -4,7 +4,7 @@
 CXX := g++
 PLUGIN_INCLUDE_DIR := $(shell $(CXX) -print-file-name=plugin)
 CXXFLAGS += -Wall -Wextra
-CXXFLAGS += -I$(PLUGIN_INCLUDE_DIR)/include -fPIC -fno-rtti -O2 -std=c++14
+CXXFLAGS += -I$(PLUGIN_INCLUDE_DIR)/include -fPIC -fno-rtti -O2 -std=c++17
 GCC_MAJOR_VERSION := $(shell $(CXX) -dumpversion)
 GCC_ARCH := $(shell $(CXX) -dumpmachine)
 

--- a/core/esstracore.cpp
+++ b/core/esstracore.cpp
@@ -52,7 +52,7 @@ int plugin_is_GPL_compatible;
 // version numbers
 static constexpr char tool_name[] = "ESSTRA Core";
 static constexpr char tool_version[] = "0.1.1-develop";
-static constexpr char data_format_version[] = "0.1.0-develop";
+static constexpr char data_format_version[] = "0.1.0";
 
 // section name
 static constexpr char section_name[] = ".esstra";

--- a/core/esstracore.cpp
+++ b/core/esstracore.cpp
@@ -267,15 +267,15 @@ create_section(void* /* gcc_data */, void* /* user_data */) {
 
         // enumerate all directories and files
         for (const auto& directory : sorted_dirs) {
-            strings_to_embed.push_back(YAML_INDENT + YAML_ITEM + KEY_DIRECTORY + ": " + directory);
-            strings_to_embed.push_back(YAML_INDENT + YAML_INDENT + KEY_FILES + ":");
+            strings_to_embed.push_back(YAML_ITEM + KEY_DIRECTORY + ": " + directory);
+            strings_to_embed.push_back(YAML_INDENT + KEY_FILES + ":");
             for (const auto& filename : dir_to_files[directory]) {
                 debug_log("dir: %s\n", directory.c_str());
-                strings_to_embed.push_back(YAML_INDENT + YAML_INDENT + YAML_ITEM + KEY_FILE + ": " + filename);
+                strings_to_embed.push_back(YAML_INDENT + YAML_ITEM + KEY_FILE + ": " + filename);
                 string path = directory + "/" + filename;
                 for (const auto& elem : infomap[path]) {
                     strings_to_embed.push_back(
-                        YAML_INDENT + YAML_INDENT + YAML_INDENT + elem.first + ": " + elem.second);
+                        YAML_INDENT + YAML_INDENT + elem.first + ": " + elem.second);
                 }
             }
         }

--- a/core/esstracore.cpp
+++ b/core/esstracore.cpp
@@ -82,6 +82,8 @@ static vector<string> specified_algos = { // embeds sha1 sum by default
 #define KEY_DATA_FORMAT_VERSION "DataFormatVersion"s
 #define KEY_INPUT_FILENAME "InputFileName"s
 #define KEY_SOURCE_FILES "SourceFiles"s
+#define KEY_DIRECTORY "Directory"s
+#define KEY_FILES "Files"s
 #define KEY_FILE "File"s
 #define KEY_MD5 "MD5"s
 #define KEY_SHA1 "SHA1"s
@@ -261,12 +263,13 @@ create_section(void* /* gcc_data */, void* /* user_data */) {
             debug_log("dir: %s\n", directory.c_str());
             if (current_directory != directory) {
                 current_directory = directory;
-                strings_to_embed.push_back(YAML_INDENT + directory + ":");
+                strings_to_embed.push_back(YAML_INDENT + YAML_ITEM + KEY_DIRECTORY + ": " + directory);
+                strings_to_embed.push_back(YAML_INDENT + YAML_INDENT + KEY_FILES + ":");
             }
-            strings_to_embed.push_back(YAML_INDENT + YAML_ITEM + KEY_FILE + ": " + filename);
+            strings_to_embed.push_back(YAML_INDENT + YAML_INDENT + YAML_ITEM + KEY_FILE + ": " + filename);
             for (const auto& elem : infomap[path]) {
                 strings_to_embed.push_back(
-                    YAML_INDENT + YAML_INDENT + elem.first + ": " + elem.second);
+                    YAML_INDENT + YAML_INDENT + YAML_INDENT + elem.first + ": " + elem.second);
             }
         }
     }

--- a/core/esstracore.cpp
+++ b/core/esstracore.cpp
@@ -267,15 +267,15 @@ create_section(void* /* gcc_data */, void* /* user_data */) {
 
         // enumerate all directories and files
         for (const auto& directory : sorted_dirs) {
-            strings_to_embed.push_back(YAML_ITEM + KEY_DIRECTORY + ": " + directory);
-            strings_to_embed.push_back(YAML_INDENT + KEY_FILES + ":");
+            strings_to_embed.push_back(YAML_INDENT + YAML_ITEM + KEY_DIRECTORY + ": " + directory);
+            strings_to_embed.push_back(YAML_INDENT + YAML_INDENT + KEY_FILES + ":");
             for (const auto& filename : dir_to_files[directory]) {
                 debug_log("dir: %s\n", directory.c_str());
-                strings_to_embed.push_back(YAML_INDENT + YAML_ITEM + KEY_FILE + ": " + filename);
+                strings_to_embed.push_back(YAML_INDENT + YAML_INDENT + YAML_ITEM + KEY_FILE + ": " + filename);
                 string path = directory + "/" + filename;
                 for (const auto& elem : infomap[path]) {
                     strings_to_embed.push_back(
-                        YAML_INDENT + YAML_INDENT + elem.first + ": " + elem.second);
+                        YAML_INDENT + YAML_INDENT + YAML_INDENT + elem.first + ": " + elem.second);
                 }
             }
         }

--- a/core/esstracore.cpp
+++ b/core/esstracore.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <set>
 #include <algorithm>
 #include <iostream>
 #include <iomanip>
@@ -41,6 +42,7 @@
 using std::vector;
 using std::string;
 using std::map;
+using std::set;
 using std::stringstream;
 using std::string_literals::operator""s;
 
@@ -237,9 +239,6 @@ static void
 create_section(void* /* gcc_data */, void* /* user_data */) {
     vector<string> strings_to_embed;
 
-    // sort allpaths
-    std::sort(allpaths.begin(), allpaths.end());
-
     // construct metadata in yaml format
     strings_to_embed.push_back(YAML_SEPARATOR);
 
@@ -251,25 +250,33 @@ create_section(void* /* gcc_data */, void* /* user_data */) {
     strings_to_embed.push_back(YAML_INDENT + KEY_INPUT_FILENAME + ": " + main_input_filename);
 
     // source files
-    string current_directory = "";
-
     if (allpaths.size() == 0) {
         strings_to_embed.push_back(KEY_SOURCE_FILES + ": {}");
     } else {
         strings_to_embed.push_back(KEY_SOURCE_FILES + ":");
+
+        // sort directories using std::set
+        set<string> sorted_dirs;
+        map<string, vector<string>> dir_to_files;
         for (const auto& path : allpaths) {
             string directory = dirname(const_cast<char*>(string(path).c_str()));
             string filename = basename(const_cast<char*>(string(path).c_str()));
-            debug_log("dir: %s\n", directory.c_str());
-            if (current_directory != directory) {
-                current_directory = directory;
-                strings_to_embed.push_back(YAML_INDENT + YAML_ITEM + KEY_DIRECTORY + ": " + directory);
-                strings_to_embed.push_back(YAML_INDENT + YAML_INDENT + KEY_FILES + ":");
-            }
-            strings_to_embed.push_back(YAML_INDENT + YAML_INDENT + YAML_ITEM + KEY_FILE + ": " + filename);
-            for (const auto& elem : infomap[path]) {
-                strings_to_embed.push_back(
-                    YAML_INDENT + YAML_INDENT + YAML_INDENT + elem.first + ": " + elem.second);
+            sorted_dirs.insert(directory);
+            dir_to_files[directory].push_back(filename);
+        }
+
+        // enumerate all directories and files
+        for (const auto& directory : sorted_dirs) {
+            strings_to_embed.push_back(YAML_ITEM + KEY_DIRECTORY + ": " + directory);
+            strings_to_embed.push_back(YAML_INDENT + KEY_FILES + ":");
+            for (const auto& filename : dir_to_files[directory]) {
+                debug_log("dir: %s\n", directory.c_str());
+                strings_to_embed.push_back(YAML_INDENT + YAML_ITEM + KEY_FILE + ": " + filename);
+                string path = directory + "/" + filename;
+                for (const auto& elem : infomap[path]) {
+                    strings_to_embed.push_back(
+                        YAML_INDENT + YAML_INDENT + elem.first + ": " + elem.second);
+                }
             }
         }
     }

--- a/samples/hello/README.md
+++ b/samples/hello/README.md
@@ -111,15 +111,22 @@ format. These files are all involved in the compilation of the file `hello`:
 
 ```yaml
 #
-# BinaryFileName: output_example/hello
-# BinaryPath: /home/snagao/esstra/samples/sample-hello/output_example/hello
+# BinaryFileName: hello
+# BinaryPath: /home/snagao/esstra/samples/hello/hello
 #
----
+Headers:
+  ToolName: ESSTRA Core
+  ToolVersion: 0.1.1-develop
+  DataFormatVersion: 0.1.0
+  InputFileNames:
+  - hello.c
 SourceFiles:
-  /home/snagao/esstra/samples/sample-hello:
+- Directory: /home/snagao/esstra/samples/hello
+  Files:
   - File: hello.c
-    SHA1: 62592ce351eab2dfb75deb8c01101e07d6fe3c67
-  /usr/include:
+    SHA1: 4bbee85215cbcb6a4f1625e4851cca19b0d3f6e2
+- Directory: /usr/include
+  Files:
   - File: features-time64.h
     SHA1: 57c3c8093c3af70e5851f6d498600e2f6e24fdeb
   - File: features.h
@@ -128,12 +135,34 @@ SourceFiles:
     SHA1: 2fef05d80514ca0be77efec90bda051cf87d771f
   - File: stdio.h
     SHA1: c7181b48c4194cd122024971527aab4056baf600
-  /usr/include/x86_64-linux-gnu/bits:
+- Directory: /usr/include/x86_64-linux-gnu/bits
+  Files:
+  - File: floatn-common.h
+    SHA1: 3f37104123a2e6180621331c1da87125808e47bd
+  - File: floatn.h
+    SHA1: 806b759ab6894a09a3b3a422eec5f2414ba7dab7
+  - File: libc-header-start.h
+    SHA1: e0a400c194cd3962a342a6504a441920163b799c
+  - File: long-double.h
+    SHA1: 4e3f5928e816ad29079d1c7d75f3a510a0939ffb
+  - File: stdio.h
+    SHA1: 521d7cd0f6572f70122386784120cc55d84899bc
+  - File: stdio2.h
+    SHA1: 6c3ee923db9679a79941a688de72e114a794fc54
+  - File: stdio_lim.h
+    SHA1: 6210c8ae410ee0f39a6096b0adb9fa86febd3517
+  - File: time64.h
+    SHA1: ab2017da21608498b58eea37b2aa6a3387ee978c
+  - File: timesize.h
+    SHA1: f1dd8d62a4d75288654626933edfc82ccf2394a7
+  - File: types.h
+    SHA1: e5893a9c4c523615c73a51feb9680279608027c6
   - File: typesizes.h
     SHA1: ee94b5a60d007c23bdda9e5c46c8ba40f4eb402c
   - File: wordsize.h
     SHA1: 281ddd3c93f1e8653e809a45b606574c9b691092
-  /usr/include/x86_64-linux-gnu/bits/types:
+- Directory: /usr/include/x86_64-linux-gnu/bits/types
+  Files:
   - File: FILE.h
     SHA1: 497924e329d53517631713ae52acb73e870d7d65
   - File: __FILE.h
@@ -146,15 +175,18 @@ SourceFiles:
     SHA1: e3a4f2ee55e635520db0b4610d2b361e9ce41de7
   - File: struct_FILE.h
     SHA1: 1dbf8bac589cb09e09aa4c1d36913e549a57bcf0
-  /usr/include/x86_64-linux-gnu/gnu:
+- Directory: /usr/include/x86_64-linux-gnu/gnu
+  Files:
   - File: stubs-64.h
     SHA1: f7603fa3908b56e9d1b33c91590db3252e13a799
   - File: stubs.h
     SHA1: be168037b7503a82b1cf694cdbac8c063bb6e476
-  /usr/include/x86_64-linux-gnu/sys:
+- Directory: /usr/include/x86_64-linux-gnu/sys
+  Files:
   - File: cdefs.h
     SHA1: a419a6372029d89ba38ada0811d34f51df8d09b7
-  /usr/lib/gcc/x86_64-linux-gnu/11/include:
+- Directory: /usr/lib/gcc/x86_64-linux-gnu/11/include
+  Files:
   - File: stdarg.h
     SHA1: fa23f49da8a0a5068b781dff7182f1a1c363dc30
   - File: stddef.h
@@ -175,17 +207,27 @@ each file grouped by directory:
 # BinaryFileName: <specified_binary_name>
 # BinaryPath: <absolute_path_of_the_specified_binary>
 #
+Headers:
+  ToolName: <esstra_tool_name>
+  ToolVersion: <esstra_tool_version>
+  DataFormatVersion: <data_format_version>
+  InputFileNames:
+  - <filename_passed_to_gcc>
+     :
+     :
 SourceFiles:
-  <directory_name>:
+- Directory: <directory_name>
+  Files:
   - File: <filename>
-    SHA1: <SHA1_checksum>
+    SHA1: <sha1_checksum>
   - File: <filename>
-    SHA1: <SHA1_checksum>
-  <directory name>:
+    SHA1: <sha1_checksum>
+- Directory: <directory name>
+  Files:
   - File: <filename>
-    SHA1: <SHA1_checksum>
+    SHA1: <sha1_checksum>
   - File: <filename>
-    SHA1: <SHA1_checksum>
+    SHA1: <sha1_checksum>
       :
       :
 ```
@@ -227,17 +269,24 @@ The result will be as follows:
 # BinaryFileName: hello
 # BinaryPath: /home/snagao/esstra/samples/hello/hello
 #
+Headers:
+  ToolName: ESSTRA Core
+  ToolVersion: 0.1.1-develop
+  DataFormatVersion: 0.1.0
+  InputFileNames:
+  - hello.c
 SourceFiles:
-  /home/snagao/esstra/samples/hello:
+- Directory: /home/snagao/esstra/samples/hello
+  Files:
   - File: hello.c
-    SHA1: e7834d0b9cb6cb116c72f0bee7da29e3d280b27e
+    SHA1: 4bbee85215cbcb6a4f1625e4851cca19b0d3f6e2
     LicenseInfo:
     - MIT
-  /usr/include:
+- Directory: /usr/include
+  Files:
   - File: features-time64.h
-
-       :
-
+    SHA1: 57c3c8093c3af70e5851f6d498600e2f6e24fdeb
+     :
 ```
 
 From the above result, we can see that the file [`hello.c`](./hello.c) has

--- a/samples/hello2/README.md
+++ b/samples/hello2/README.md
@@ -121,19 +121,21 @@ And you will get a result as follows:
 Headers:
   ToolName: ESSTRA Core
   ToolVersion: 0.1.1-develop
-  DataFormatVersion: 0.1.0-develop
+  DataFormatVersion: 0.1.0
   InputFileNames:
   - hello_main.c
   - hello_sub.c
 SourceFiles:
-  /home/snagao/snagao/esstra/samples/hello2:
+- Directory: /home/snagao/esstra/samples/hello2
+  Files:
   - File: hello_main.c
     SHA1: f7f5c447d68fd9685594a31cb10c8d8b1dd5ebd6
   - File: hello_sub.c
     SHA1: cfb72998ae0242237fa42c8bcf61ee5887137392
   - File: hello_sub.h
-    SHA1: ae424fc2fd0c4bdaead89092a56e52ee2152710d
-  /usr/include:
+    SHA1: 3e5b3ed1aed966c0e0c183eac8fe6ea02dfa62a0
+- Directory: /usr/include
+  Files:
   - File: features-time64.h
     SHA1: 57c3c8093c3af70e5851f6d498600e2f6e24fdeb
   - File: features.h
@@ -142,12 +144,34 @@ SourceFiles:
     SHA1: 2fef05d80514ca0be77efec90bda051cf87d771f
   - File: stdio.h
     SHA1: c7181b48c4194cd122024971527aab4056baf600
-  /usr/include/x86_64-linux-gnu/bits:
+- Directory: /usr/include/x86_64-linux-gnu/bits
+  Files:
+  - File: floatn-common.h
+    SHA1: 3f37104123a2e6180621331c1da87125808e47bd
+  - File: floatn.h
+    SHA1: 806b759ab6894a09a3b3a422eec5f2414ba7dab7
+  - File: libc-header-start.h
+    SHA1: e0a400c194cd3962a342a6504a441920163b799c
+  - File: long-double.h
+    SHA1: 4e3f5928e816ad29079d1c7d75f3a510a0939ffb
+  - File: stdio.h
+    SHA1: 521d7cd0f6572f70122386784120cc55d84899bc
+  - File: stdio2.h
+    SHA1: 6c3ee923db9679a79941a688de72e114a794fc54
+  - File: stdio_lim.h
+    SHA1: 6210c8ae410ee0f39a6096b0adb9fa86febd3517
+  - File: time64.h
+    SHA1: ab2017da21608498b58eea37b2aa6a3387ee978c
+  - File: timesize.h
+    SHA1: f1dd8d62a4d75288654626933edfc82ccf2394a7
+  - File: types.h
+    SHA1: e5893a9c4c523615c73a51feb9680279608027c6
   - File: typesizes.h
     SHA1: ee94b5a60d007c23bdda9e5c46c8ba40f4eb402c
   - File: wordsize.h
     SHA1: 281ddd3c93f1e8653e809a45b606574c9b691092
-  /usr/include/x86_64-linux-gnu/bits/types:
+- Directory: /usr/include/x86_64-linux-gnu/bits/types
+  Files:
   - File: FILE.h
     SHA1: 497924e329d53517631713ae52acb73e870d7d65
   - File: __FILE.h
@@ -160,15 +184,18 @@ SourceFiles:
     SHA1: e3a4f2ee55e635520db0b4610d2b361e9ce41de7
   - File: struct_FILE.h
     SHA1: 1dbf8bac589cb09e09aa4c1d36913e549a57bcf0
-  /usr/include/x86_64-linux-gnu/gnu:
+- Directory: /usr/include/x86_64-linux-gnu/gnu
+  Files:
   - File: stubs-64.h
     SHA1: f7603fa3908b56e9d1b33c91590db3252e13a799
   - File: stubs.h
     SHA1: be168037b7503a82b1cf694cdbac8c063bb6e476
-  /usr/include/x86_64-linux-gnu/sys:
+- Directory: /usr/include/x86_64-linux-gnu/sys
+  Files:
   - File: cdefs.h
     SHA1: a419a6372029d89ba38ada0811d34f51df8d09b7
-  /usr/lib/gcc/x86_64-linux-gnu/11/include:
+- Directory: /usr/lib/gcc/x86_64-linux-gnu/11/include
+  Files:
   - File: stdarg.h
     SHA1: fa23f49da8a0a5068b781dff7182f1a1c363dc30
   - File: stddef.h
@@ -214,26 +241,29 @@ You will get the result shown below:
 Headers:
   ToolName: ESSTRA Core
   ToolVersion: 0.1.1-develop
-  DataFormatVersion: 0.1.0-develop
+  DataFormatVersion: 0.1.0
   InputFileNames:
   - hello_main.c
   - hello_sub.c
 SourceFiles:
-  /home/snagao/esstra/samples/hello2:
+- Directory: /home/snagao/esstra/samples/hello2
+  Files:
   - File: hello_main.c
+    SHA1: f7f5c447d68fd9685594a31cb10c8d8b1dd5ebd6
     LicenseInfo:
     - MIT
-    SHA1: f7f5c447d68fd9685594a31cb10c8d8b1dd5ebd6
   - File: hello_sub.c
+    SHA1: cfb72998ae0242237fa42c8bcf61ee5887137392
     LicenseInfo:
     - BSD-3-Clause
-    SHA1: cfb72998ae0242237fa42c8bcf61ee5887137392
   - File: hello_sub.h
+    SHA1: 3e5b3ed1aed966c0e0c183eac8fe6ea02dfa62a0
     LicenseInfo:
     - LGPL-2.1-or-later
-    SHA1: ae424fc2fd0c4bdaead89092a56e52ee2152710d
-  /usr/include:
+- Directory: /usr/include
+  Files:
   - File: features-time64.h
+    SHA1: 57c3c8093c3af70e5851f6d498600e2f6e24fdeb
 
        :
 

--- a/util/README.md
+++ b/util/README.md
@@ -78,14 +78,16 @@ would give you an output as follows:
 Headers:
   ToolName: ESSTRA Core
   ToolVersion: 0.1.1-develop
-  DataFormatVersion: 0.1.0-develop
+  DataFormatVersion: 0.1.0
   InputFileNames:
   - hello.c
 SourceFiles:
-  /home/snagao/esstra/samples/hello:
+- Directory: /home/snagao/esstra/samples/hello
+  Files:
   - File: hello.c
     SHA1: 62592ce351eab2dfb75deb8c01101e07d6fe3c67
-  /usr/include:
+- Directory: /usr/include
+  Files:
   - File: features-time64.h
     SHA1: 57c3c8093c3af70e5851f6d498600e2f6e24fdeb
   - File: features.h
@@ -113,34 +115,37 @@ $ esstra.py show hello | yq -oj
   "Headers": {
     "ToolName": "ESSTRA Core",
     "ToolVersion": "0.1.1-develop",
-    "DataFormatVersion": "0.1.0-develop",
+    "DataFormatVersion": "0.1.0",
     "InputFileNames": [
       "hello.c"
     ]
   },
-  "SourceFiles": {
-    "/home/snagao/esstra/samples/hello": [
-      {
-        "File": "hello.c",
-        "SHA1": "62592ce351eab2dfb75deb8c01101e07d6fe3c67"
-      }
-    ],
-    "/usr/include": [
-      {
-        "File": "features-time64.h",
-        "SHA1": "57c3c8093c3af70e5851f6d498600e2f6e24fdeb"
-      },
-      {
-        "File": "features.h",
-        "SHA1": "d8725bb98129d6d70ddcbf010021c2841db783f7"
-      },
-      {
-        "File": "stdc-predef.h",
-        "SHA1": "2fef05d80514ca0be77efec90bda051cf87d771f"
-      },
-          :
-        (snip)
-          :
+  "SourceFiles": [
+    {
+      "Directory": "/home/snagao/esstra/samples/hello",
+      "Files": [
+        {
+          "File": "hello.c",
+          "SHA1": "62592ce351eab2dfb75deb8c01101e07d6fe3c67"
+        }
+      ],
+      "Directory": "/usr/include",
+      "Files": [
+        {
+          "File": "features-time64.h",
+          "SHA1": "57c3c8093c3af70e5851f6d498600e2f6e24fdeb"
+        },
+        {
+          "File": "features.h",
+          "SHA1": "d8725bb98129d6d70ddcbf010021c2841db783f7"
+        },
+        {
+          "File": "stdc-predef.h",
+          "SHA1": "2fef05d80514ca0be77efec90bda051cf87d771f"
+        },
+            :
+          (snip)
+            :
 ```
 
 ## Command "shrink"

--- a/util/esstra.py
+++ b/util/esstra.py
@@ -89,13 +89,19 @@ class MetadataHandler:
         return self._shrunk_data
 
     def enumerate_files(self):
-        assert self.KEY_SOURCE_FILES in self._shrunk_data
-        source_files = self._shrunk_data[self.KEY_SOURCE_FILES]
-        for directory, files in source_files.items():
-            for fileinfo in files:
-                abs_path = str(Path(directory) / fileinfo[self.KEY_FILE])
+        if self.KEY_SOURCE_FILES not in self._shrunk_data:
+            raise RuntimeError('wrong data format: {self.KEY_SOURCE_FILES} not found')
+        sourcefiles = self._shrunk_data[self.KEY_SOURCE_FILES]
+        for directory in sourcefiles:
+            path = directory[self.KEY_DIRECTORY]
+            if self.KEY_FILES not in directory:
+                raise RuntimeError('wrong data format: {self.KEY_FILES} not found')
+            for fileinfo in directory[self.KEY_FILES]:
+                assert self.KEY_FILE in fileinfo, fileinfo
+                assert self.HASH_ALGORITHM in fileinfo
+                filepath = str(Path(path) / fileinfo[self.KEY_FILE])
                 checksum = fileinfo[self.HASH_ALGORITHM]
-                yield abs_path, checksum, fileinfo
+                yield filepath, checksum, fileinfo
 
     def update_metadata(self, binary_path,
                         create_backup, backup_suffix, overwrite_backup):


### PR DESCRIPTION
The YAML data schema in ESSTRA version 0.1.0 has a design issue:

- Directory names are represented using YAML tags.
- Some YAML parsers impose limitations on tag length.
- In certain cases, these limitations are hardcoded.
- The YAML specification itself does not define any constraints on tag length.
 
To eliminate dependencies on parser-specific implementations and limitations, we will revise the YAML data format as shown below, and set the DataFormatVersion to 0.1.0.

```yaml
Headers:
  ToolName: ESSTRA Core
  ToolVersion: 0.1.1-develop
  DataFormatVersion: 0.1.0
  InputFileNames:
  - hello.c
SourceFiles:
- Directory: /home/snagao/esstra/samples/hello
  Files:
  - File: hello.c
    SHA1: 4bbee85215cbcb6a4f1625e4851cca19b0d3f6e2
    LicenseInfo:
    - MIT
- Directory: /usr/include
  Files:
  - File: features-time64.h
    SHA1: 57c3c8093c3af70e5851f6d498600e2f6e24fdeb
  - File: features.h
    SHA1: d8725bb98129d6d70ddcbf010021c2841db783f7
  - File: stdc-predef.h
    SHA1: 2fef05d80514ca0be77efec90bda051cf87d771f
  - File: stdio.h
    SHA1: c7181b48c4194cd122024971527aab4056baf600
- Directory: /usr/include/x86_64-linux-gnu/bits
  Files:
  - File: floatn-common.h
    SHA1: 3f37104123a2e6180621331c1da87125808e47bd
  - File: floatn.h
    SHA1: 806b759ab6894a09a3b3a422eec5f2414ba7dab7
      :
   (snip)
      :
```