### PR TITLE
Add CPPFLAGS and LDFLAGS for hardening

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -35,7 +35,7 @@ $(WJCRYPTLIB_FILES):
 	(cd $(THIRD_PARTY_DIR) && git submodule init && git submodule update)
 
 $(ESSTRACORE): $(ESSTRACORE_SOURCES)
-	$(CXX) -shared $(CXXFLAGS) $^ -o $@
+	$(CXX) -shared $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ -o $@
 
 install: $(ESSTRACORE)
 	install -m 755 -d $(INSTALLDIR)


### PR DESCRIPTION
Some distro like Debian have default hardening flags, so specifying CFLAGS, CPPFLAGS, CXXFLAGS and LDFLAGS by default is better.

If GCC (or other compiler) would add new flags, distro may introduce it as default and just rebuild package for hardenings, instead of adding new flags to all sources.

For detail, see https://wiki.debian.org/Hardening