### PR TITLE
Use CC instead of CXX for sample compilation setup

### DIFF
--- a/samples/hello/Makefile
+++ b/samples/hello/Makefile
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 CC := gcc
-GCC_MAJOR_VERSION := $(shell $(CXX) -dumpversion)
-GCC_ARCH := $(shell $(CXX) -dumpmachine)
+GCC_MAJOR_VERSION := $(shell $(CC) -dumpversion)
+GCC_ARCH := $(shell $(CC) -dumpmachine)
 
 PREFIX ?= /usr/local
 GCC_PLUGIN_DIR := $(DESTDIR)/$(PREFIX)/lib/gcc/$(GCC_ARCH)/$(GCC_MAJOR_VERSION)/plugin

--- a/samples/hello2/Makefile
+++ b/samples/hello2/Makefile
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 CC := gcc
-GCC_MAJOR_VERSION := $(shell $(CXX) -dumpversion)
-GCC_ARCH := $(shell $(CXX) -dumpmachine)
+GCC_MAJOR_VERSION := $(shell $(CC) -dumpversion)
+GCC_ARCH := $(shell $(CC) -dumpmachine)
 
 PREFIX ?= /usr/local
 GCC_PLUGIN_DIR := $(DESTDIR)/$(PREFIX)/lib/gcc/$(GCC_ARCH)/$(GCC_MAJOR_VERSION)/plugin


### PR DESCRIPTION
In some minimal cases, when I use sample sources for test but g++ is not installed and test fails.
(And I do not want introduce unnecessary dependency for the test to keep it minimal).