### PR TITLE
Set PATH_MAX for some OSes (e.g. hurd)

### DIFF
--- a/core/esstracore.cpp
+++ b/core/esstracore.cpp
@@ -171,6 +171,14 @@ collect_paths(void* gcc_data, void* /* user_data */) {
 
     // get absolute path
 
+    /*
+     * Some OSes (e.g. Hurd) explicitly need to specify PATH_MAX
+     * "4096" is specified in Linux, see /usr/include/linux/limits.h
+     */
+    #ifndef PATH_MAX
+    #define PATH_MAX 4096
+    #endif
+
     char resolved[PATH_MAX];
     if (!realpath(path.c_str(), resolved)) {
         perror((path + ": realpath() failed").c_str());


### PR DESCRIPTION
Debian has GNU/Hurd port and esstra is built for them as well.
Without specifying PATH_MAX, it fails to be built on hurd and this patch fixes it.

See https://buildd.debian.org/status/logs.php?pkg=esstra&arch=hurd-amd64