### PR TITLE
util update: match files on the strongest hash available on both sides

### DIFF
--- a/util/README.md
+++ b/util/README.md
@@ -169,6 +169,10 @@ The two are stored in separate metadata fields: detected licenses go to
 scanner's guess from a reviewer's decision. `NOASSERTION` / `NONE` values are
 skipped.
 
+Files in the binary's metadata are matched against the SPDX entries by
+checksum, using the strongest hash algorithm present on both sides
+(SHA-256 preferred over SHA-1).
+
 A typical usage is:
 
 ```sh

--- a/util/esstra
+++ b/util/esstra
@@ -92,6 +92,7 @@ class MetadataHandler:
     KEY_LICENSE_DETECTED = 'LicenseDetected'
     KEY_LICENSE_CONCLUDED = 'LicenseConcluded'
     HASH_ALGORITHM = 'SHA1'
+    HASH_ALGORITHMS = ('SHA256', 'SHA1')  # strongest first
 
     def __init__(self, binary_path):
         if not Path(binary_path).exists():
@@ -433,7 +434,7 @@ class SpdxTagValueInfo:
     TAG_TEXT_BEGIN = '<text>'
     TAG_TEXT_END = '</text>'
     GROUP_HEADERS = (TAG_FILE_NAME, TAG_LICENSE_ID)
-    HASH_ALGORITHM = 'SHA1'
+    HASH_ALGORITHMS = ('SHA256', 'SHA1')  # strongest first
 
     def __init__(self):
         self._fileinfos = {}
@@ -443,18 +444,25 @@ class SpdxTagValueInfo:
             lines = fp.readlines()
         self.__update_fileinfos(lines)
 
-    def get_fileinfo(self, path, checksum):
-        if checksum not in self._fileinfos:
-            msg.debug(f'* path {path!r} with sum {checksum!r} not found')
-            return None
-
-        for fileinfo in self._fileinfos[checksum]:
-            filepath = fileinfo[self.TAG_FILE_NAME][0]
-            if self.__check_filepath(path, filepath):
-                msg.debug(f'* FOUND: {path!r} with sum {checksum!r}')
+    def get_fileinfo(self, path, checksums):
+        for algorithm in self.HASH_ALGORITHMS:
+            checksum = checksums.get(algorithm)
+            if not checksum or checksum not in self._fileinfos:
+                continue
+            for fileinfo in self._fileinfos[checksum]:
+                filepath = fileinfo[self.TAG_FILE_NAME][0]
+                if not self.__check_filepath(path, filepath):
+                    continue
+                if self.__strongest_common_algorithm(
+                        checksums, fileinfo) != algorithm:
+                    msg.debug(f'* skip {algorithm} match for {path!r}: '
+                              f'a stronger shared hash exists')
+                    continue
+                msg.debug(f'* FOUND: {path!r} via {algorithm}:{checksum!r}')
                 return fileinfo
+            msg.debug(f'* {algorithm}:{checksum!r} found but path {path!r} not matched')
 
-        msg.debug(f'* sum {checksum!r} found but path {path!r} not matched: {filepath!r}')
+        msg.debug(f'* no checksum match for {path!r}: {checksums!r}')
         return None
 
     # private
@@ -471,20 +479,36 @@ class SpdxTagValueInfo:
                 fileinfo.setdefault(tag, [])
                 fileinfo[tag].append(value)
 
-        # update self._fileinfo as a dict whose keys are checksums
-        checksum = None
+        # index file info under every checksum algorithm we understand
         for fileinfo in fileinfo_list:
-            if self.TAG_FILE_CHECKSUM in fileinfo:
-                for checksum_value in fileinfo[self.TAG_FILE_CHECKSUM]:
-                    if checksum_value.startswith(self.HASH_ALGORITHM):
-                        checksum = checksum_value.split()[1]
-                        self._fileinfos.setdefault(checksum, [])
-                        self._fileinfos[checksum].append(fileinfo)
+            if self.TAG_FILE_CHECKSUM not in fileinfo:
+                continue
+            for checksum_value in fileinfo[self.TAG_FILE_CHECKSUM]:
+                parts = checksum_value.split()
+                if len(parts) < 2:
+                    continue
+                algorithm = parts[0].rstrip(':')
+                if algorithm in self.HASH_ALGORITHMS:
+                    checksum = parts[1]
+                    self._fileinfos.setdefault(checksum, [])
+                    self._fileinfos[checksum].append(fileinfo)
 
     @staticmethod
     def __check_filepath(spdx_filename, path):
         # TODO: use more accurate comparison
         return Path(spdx_filename).name == Path(path).name
+
+    @classmethod
+    def __strongest_common_algorithm(cls, checksums, fileinfo):
+        fileinfo_algorithms = set()
+        for checksum_value in fileinfo.get(cls.TAG_FILE_CHECKSUM, []):
+            parts = checksum_value.split()
+            if len(parts) >= 2:
+                fileinfo_algorithms.add(parts[0].rstrip(':'))
+        for algorithm in cls.HASH_ALGORITHMS:
+            if algorithm in checksums and algorithm in fileinfo_algorithms:
+                return algorithm
+        return None
 
     @classmethod
     def __parse_tag_value_lines(cls, lines):
@@ -836,7 +860,12 @@ class CommandUpdate(CommandBase):
                 continue
 
             for _, filepath, checksum, fileinfo in handler.enumerate_files():
-                spdx_fileinfo = spdx_info.get_fileinfo(filepath, checksum)
+                checksums = {
+                    algorithm: fileinfo[algorithm]
+                    for algorithm in MetadataHandler.HASH_ALGORITHMS
+                    if algorithm in fileinfo
+                }
+                spdx_fileinfo = spdx_info.get_fileinfo(filepath, checksums)
                 if not spdx_fileinfo:
                     continue
 


### PR DESCRIPTION
Closes #55.

## What this PR does

Implements the strongest-hash matching proposed in #55 (see the issue for the motivation):

- `SpdxTagValueInfo` indexes each SPDX file entry under every checksum algorithm it understands (`SHA256`, `SHA1`) instead of SHA-1 only, and `get_fileinfo()` matches on the strongest hash present on both sides. When the `.esstra` metadata and the SPDX entry both carry SHA-256, the match is decided by SHA-256 alone
— a SHA-1 match is never used to override a SHA-256 mismatch, so a SHA-1 collision cannot mislink two different files. SHA-1 is used only when a side does not carry SHA-256.
- SHA-1 remains always-recorded and remains the deduplication key; ESSTRA Core is unchanged. For every existing setup (SHA-1-only metadata and/or SPDX) the fallback path is exactly the old path.
- `util/README.md`: one sentence documenting the matching rule.

## How it was verified

All on the bundled hello sample:

- Built as-is (SHA-1-only metadata): `esstra update` + `esstra show` behave exactly as before — the fallback path is the old path.
- Built with `-fplugin-arg-esstracore-checksum=sha256`: `esstra update` with the bundled sample SPDX that carries `FileChecksum: SHA256:` (`SPDX2TV_esstra_fossology.spdx`) matches via SHA-256 (confirmed with the debug log), and the recorded metadata carries both hashes.

The strongest-shared-hash rule was checked directly against `get_fileinfo()` with crafted inputs:

- Both sides carry differing SHA-256 while SHA-1 collides and the file name matches: no match is returned — the SHA-1 collision does not override the SHA-256 mismatch.
- Matching SHA-256, and the SHA-1-only fallback cases, resolve exactly as before (no regression).